### PR TITLE
Update DCOLLECT Parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 docs/_build/*
-src/mfpandas/__pycache__/*
-src/mfpandas/mfpandas.egg-info/*
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ build:
 
 upload:
 	python -m twine upload --skip-existing --repository pypi dist/*
+
+test:
+	PYTHONPATH=src python -m unittest discover -s tests -v

--- a/docs/dcollect.rst
+++ b/docs/dcollect.rst
@@ -15,8 +15,11 @@ For all examples here we're assuming you've already ran the following code::
 
     d = DCOLLECT('/path/to/dcolfile')
     d.parse()
-    while d.status['status'] != 'Ready':
+    while d.status['status'] not in ('Ready', 'Error'):
         time.sleep(1)
+
+    if d.status['status'] == 'Error':
+        raise RuntimeError(d.status['error'])
 
 
 To find all datasets starting with 'SYS1' and the volulme they're on::
@@ -40,6 +43,30 @@ To find all datasets on a volume::
 
     >>> d.datsets_on_volume(volser='A5DBAR')
     ['SYS1.VTOCIX.A5DBAR', 'SYS1.VVDS.VA5DBAR']
+
+
+Missing dates and encryption information
+****************************************
+
+Packed DCOLLECT dates containing zero or invalid values are returned as
+``None`` rather than terminating the background parser. Before 0.1.8 these
+were returned as ``False``, so replace any ``== False`` filters on
+``DCDCREDT``, ``DCDEXPDT`` or ``DCDLSTRF`` with ``.isnull()``.
+
+Dataset records also expose ``DCDATYPE`` and ``DCDAKLBL``. ``DCDATYPE`` is
+``0100`` for AES-256 XTS encryption and ``FFFF`` for an unencrypted data set;
+``DCDAKLBL`` holds the key label and is blank for unencrypted data sets. Both
+are empty for D-records written before APAR OA51067, which are too short to
+contain them.
+
+
+VSAM associations
+*****************
+
+The ``associations`` property exposes parsed type-A records. ``DCADSNAM`` is
+the component data set and ``DCAASSOC`` is its associated base cluster. The
+``DCAKSDS``, ``DCAESDS``, ``DCARRDS``, and ``DCALDS`` Boolean columns describe
+the VSAM organization.
 
 
 

--- a/docs/setropts.rst
+++ b/docs/setropts.rst
@@ -1,10 +1,19 @@
 Working with SETROPTS LIST data
 ###############################
 
-The :py:class:`mfpandas.SETROPTS` is made to work with your SETROPTS data. 
-Because parsing the output of `SETROPTS LIST` is troublesome to say the least a REXX
-is provided to create the SETROPTS export this class can work with.
+The :py:class:`mfpandas.SETROPTS` is made to work with your SETROPTS data.
+There are two ways to feed it:
 
+* **Option A (recommended): the IRRXUTIL REXX.** Run the provided REXX on the
+  mainframe to create a clean ``KEY:VALUE`` extract dataset and transfer it down.
+* **Option B: convert existing ``SETROPTS LIST`` output.** If you already have a
+  ``SETROPTS LIST`` capture (from a TSO session or the JES spool), convert it
+  locally instead of running anything on the mainframe. See
+  :ref:`setropts-list-conversion` below.
+
+
+Option A: the IRRXUTIL REXX
+***************************
 
 This REXX is retrieved from the SETROPTS class like below::
 
@@ -56,6 +65,34 @@ This REXX is retrieved from the SETROPTS class like below::
                                                                 
     say "Done"     
 
+
+
+.. _setropts-list-conversion:
+
+Option B: convert SETROPTS LIST output
+**************************************
+
+If running the REXX is not convenient, you can convert a plain ``SETROPTS LIST``
+capture into the same ``KEY:VALUE`` format. Both a TSO terminal capture and a
+JES/SDSF spool capture (with ASA carriage-control) are handled.
+
+Build a :py:class:`mfpandas.SETROPTS` directly from the captured text or a file::
+
+    >>> from mfpandas import SETROPTS
+    >>> s = SETROPTS.from_setropts_list('/home/henri/setropts-list.txt')
+    >>> s.classInfo
+
+Or convert to a ``KEY:VALUE`` file from the command line, then load it the same
+way as a REXX extract::
+
+    $ mfpandas-setropts-list setropts-list.txt -o WIZARD.SETROPTS.D250101
+    >>> s = SETROPTS('WIZARD.SETROPTS.D250101')
+
+.. note::
+
+   The converter only emits the settings represented by the IRRXUTIL extract, so
+   a few fields available through Option A are not reconstructed from
+   ``SETROPTS LIST`` text. Prefer Option A when you can run the REXX.
 
 
 SETROPTS Examples

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.rst", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="mfpandas",
-    version="0.1.7",
+    version="0.1.8",
     author="Wizard of z/OS",
     author_email="wizard@zdevops.com",
     description="Parsing various z/OS structures into Panda dataframes.",
@@ -27,6 +27,11 @@ setuptools.setup(
         },
     packages=setuptools.find_packages(where="src"),
     include_package_data=True,
+    entry_points={
+        "console_scripts": [
+            "mfpandas-setropts-list=mfpandas.setropts_list:main",
+        ],
+    },
     install_requires=[
         'wheel',
         'pandas>=1.5.2',

--- a/src/mfpandas/__init__.py
+++ b/src/mfpandas/__init__.py
@@ -3,7 +3,8 @@ class MFPandasException(Exception):
         self.message = message
         super().__init__(self.message)
 
-from .dcollect import DCOLLECT 
-from .irrdbu00 import IRRDBU00 
+from .dcollect import DCOLLECT
+from .irrdbu00 import IRRDBU00
 from .setropts import SETROPTS
+from .setropts_list import convert as setropts_list_to_key_value
 

--- a/src/mfpandas/dcollect.py
+++ b/src/mfpandas/dcollect.py
@@ -53,16 +53,15 @@ class DCOLLECT:
     STATE_PARSING     =  1
     STATE_READY       =  2
 
-    # Counters
-    records_seen = {}
-    records_parsed = {}
+    # Length of DCUHDR, the header every DCOLLECT record starts with.
+    HEADER_LENGTH     = 24
 
     def __init__(self, dcollect=None):
         """
         Initialize the DCOLLECT class.
         Recordlayout from: https://www.ibm.com/docs/en/zos/3.1.0?topic=output-dcollect-record-structure
 
-        Recordtypes supported: D (Datasets), V (Volumes), DC (DataClass).
+        Recordtypes supported: D (Datasets), A (VSAM associations), V (Volumes), DC (DataClass).
 
         :param dcollect: Full path to DCOLLECT file
         :type dcollect: str
@@ -81,7 +80,10 @@ class DCOLLECT:
             raise UsageError("No DCOLLECT file specified.")
         self._dcolfile = dcollect
 
-        self._state = self.STATE_INIT 
+        self._state = self.STATE_INIT
+        self._error = None
+        self.records_seen = {}
+        self.records_parsed = {}
 
         self._DRECS = {
             'DCDDSNAM': [],
@@ -135,8 +137,18 @@ class DCOLLECT:
             'DCDATCL': [],
             'DCDSTGCL': [],
             'DCDMGTCL': [],
-            'DCDSTGRP': []
+            'DCDSTGRP': [],
+            'DCDATYPE': [],
+            'DCDAKLBL': []
             }
+        self._ARECS = {
+            'DCADSNAM': [],
+            'DCAASSOC': [],
+            'DCAKSDS': [],
+            'DCAESDS': [],
+            'DCARRDS': [],
+            'DCALDS': []
+        }
         self._VRECS = {
             'DCVVOLSR': [],
             'DCVPERCT': [],
@@ -314,7 +326,18 @@ class DCOLLECT:
             'DDCDKLBN': []     # DASD key label name
         }
 
-    def parse_t(self):
+    @staticmethod
+    def _packed_date(raw):
+        """Return a date for a packed YYYYDDD field, or None when unset/invalid."""
+        value = raw.hex()[:7]
+        if value == '0000000' or value[4:] == '000':
+            return None
+        try:
+            return datetime.datetime.strptime(value, '%Y%j').date()
+        except (TypeError, ValueError):
+            return None
+
+    def _parse_t(self):
         """
         Function to parse the dcollect file.
         This function is called inside a thread via the parse() function.
@@ -329,13 +352,22 @@ class DCOLLECT:
         with open(self._dcolfile, 'rb') as fid:
             self._state = self.STATE_PARSING
             while True:
-                try:
-                    DCULENG = int(fid.read(2).hex(),16)
-                except:
-                    # we must have hit the end of the file :)
+                header = fid.read(2)
+                if not header:
                     break
+                if len(header) != 2:
+                    raise ValueError('Truncated DCOLLECT record-length field')
+                DCULENG = int.from_bytes(header, byteorder='big')
+                # DCULENG covers the whole record, header (DCUHDR) included.
+                if DCULENG < self.HEADER_LENGTH:
+                    raise ValueError(f'Invalid DCOLLECT record length: {DCULENG}')
                 #print('Have a record of',DCULENG,'bytes')
                 restrec = fid.read(DCULENG-2)
+                if len(restrec) != DCULENG - 2:
+                    raise ValueError(
+                        f'Truncated DCOLLECT record: expected {DCULENG - 2} bytes, '
+                        f'got {len(restrec)}'
+                    )
                 DCURCTYP = restrec[2:4].decode('cp500').strip()
                 if DCURCTYP in self.records_seen:
                     self.records_seen[DCURCTYP] += 1
@@ -418,31 +450,10 @@ class DCOLLECT:
                     self._DRECS['DCDBKLNG'].append(int(restrec[82:84].hex(),16))
                     self._DRECS['DCDLRECL'].append(int(restrec[84:86].hex(),16))
 
-                    # formats = yyyydddF
-                    createraw = restrec[102:106].hex()[0:7]
-                    crdte = datetime.datetime.strptime(createraw, '%Y%j').date()
-                    self._DRECS['DCDCREDT'].append(crdte)
-
-                    expraw = restrec[106:110].hex()[0:7]
-                    if expraw == '0000000':
-                        expdte = False
-                    elif expraw[4:] == '000':
-                        expdte = False 
-                    else:
-                        try:
-                            expdte =  datetime.datetime.strptime(expraw, '%Y%j').date()
-                        except:
-                            # https://www.mxg.com/changes/chng0808.asp
-                            expdte = False
-                    
-                    self._DRECS['DCDEXPDT'].append(expdte)
-
-                    lrraw = restrec[110:114].hex()[0:7]
-                    if lrraw == '0000000':
-                        lrdte = False
-                    else:
-                        lrdte = datetime.datetime.strptime(lrraw, '%Y%j').date()
-                    self._DRECS['DCDLSTRF'].append(lrdte)
+                    # Packed dates use yyyydddF; zero and invalid dates are unset.
+                    self._DRECS['DCDCREDT'].append(self._packed_date(restrec[102:106]))
+                    self._DRECS['DCDEXPDT'].append(self._packed_date(restrec[106:110]))
+                    self._DRECS['DCDLSTRF'].append(self._packed_date(restrec[110:114]))
 
 
 
@@ -471,8 +482,31 @@ class DCOLLECT:
                     else:
                         self._DRECS['DCDSTGRP'].append('*NONE*')
 
+                    # DCDAENCR (encryption) was added by APAR OA51067. Older,
+                    # shorter D-records stop before it.
+                    if len(restrec) >= 450:
+                        self._DRECS['DCDATYPE'].append(restrec[384:386].hex().upper())
+                        # Unset key labels are binary zeros, not EBCDIC blanks.
+                        self._DRECS['DCDAKLBL'].append(restrec[386:450].decode('cp500').strip(' \x00'))
+                    else:
+                        self._DRECS['DCDATYPE'].append('')
+                        self._DRECS['DCDAKLBL'].append('')
+
                     
                     self.records_parsed['D'] += 1
+                elif DCURCTYP == 'A':
+                    if len(restrec) < 111:
+                        raise ValueError(
+                            f'Truncated DCOLLECT A-record: {len(restrec) + 2} bytes'
+                        )
+                    DCAFLAG1 = restrec[110]
+                    self._ARECS['DCADSNAM'].append(restrec[22:66].decode('cp500').strip())
+                    self._ARECS['DCAASSOC'].append(restrec[66:110].decode('cp500').strip())
+                    self._ARECS['DCAKSDS'].append((DCAFLAG1 & 0b10000000) != 0)
+                    self._ARECS['DCAESDS'].append((DCAFLAG1 & 0b01000000) != 0)
+                    self._ARECS['DCARRDS'].append((DCAFLAG1 & 0b00100000) != 0)
+                    self._ARECS['DCALDS'].append((DCAFLAG1 & 0b00010000) != 0)
+                    self.records_parsed['A'] += 1
                 elif DCURCTYP == 'V':
                     self._VRECS['DCVVOLSR'].append(restrec[22:28].decode('cp500').strip())
                     self._VRECS['DCVPERCT'].append(int(restrec[33:34].hex(),16))
@@ -793,11 +827,22 @@ class DCOLLECT:
 
             self.drecs = pd.DataFrame.from_dict(self._DRECS)
             del self._DRECS
+            self.arecs = pd.DataFrame.from_dict(self._ARECS)
+            del self._ARECS
             self.vrecs = pd.DataFrame.from_dict(self._VRECS)
             del self._VRECS
             self.dcrecs = pd.DataFrame.from_dict(self._DCRECS)
             del self._DCRECS
             self._state = self.STATE_READY
+
+    def parse_t(self):
+        """Parse synchronously and retain failures for asynchronous callers."""
+        try:
+            self._parse_t()
+        except Exception as exc:
+            self._error = exc
+            self._state = self.STATE_BAD
+        return self._state == self.STATE_READY
 
     def parse(self):
         """
@@ -830,7 +875,7 @@ class DCOLLECT:
             24-06-30 15:07:08 - Done.
             24-06-30 15:07:08   - 37 V-records seen, 37 parsed
             24-06-30 15:07:08   - 6704 D-records seen, 6704 parsed
-            24-06-30 15:07:08   - 1392 A-records seen, 0 parsed
+            24-06-30 15:07:08   - 1392 A-records seen, 1392 parsed
             24-06-30 15:07:08   - 12 DC-records seen, 0 parsed
             24-06-30 15:07:08   - 12 SC-records seen, 0 parsed
             24-06-30 15:07:08   - 2 MC-records seen, 0 parsed
@@ -844,10 +889,12 @@ class DCOLLECT:
         """            
         print(f'{datetime.datetime.now().strftime("%y-%m-%d %H:%M:%S")} - parsing {self._dcolfile}')
         self.parse()
-        while self._state < self.STATE_READY:
+        while self._state in (self.STATE_INIT, self.STATE_PARSING):
             print(f'{datetime.datetime.now().strftime("%y-%m-%d %H:%M:%S")} - {self.status["status"]}', end='\r', flush=True)
             time.sleep(0.5)
         print('')
+        if self._state == self.STATE_BAD:
+            raise UsageError(f'DCOLLECT parsing failed: {self._error}')
         print(f'{datetime.datetime.now().strftime("%y-%m-%d %H:%M:%S")} - Done.')
         for t in self.records_parsed:
             print(f'{datetime.datetime.now().strftime("%y-%m-%d %H:%M:%S")}   - {self.records_seen[t]} {t}-records seen, {self.records_parsed[t]} parsed')
@@ -900,11 +947,26 @@ class DCOLLECT:
 
 
         """       
+        result = {
+            'records_seen': self.records_seen,
+            'records_parsed': self.records_parsed,
+        }
         if self._state == self.STATE_READY:
-            return {'status': 'Ready', 'records_seen': self.records_seen, 'records_parsed': self.records_parsed}
+            result['status'] = 'Ready'
+        elif self._state == self.STATE_BAD:
+            result['status'] = 'Error'
+            result['error'] = str(self._error)
         else:
-            return {'status': "Still Parsing your input", 'records_seen': self.records_seen, 'records_parsed': self.records_parsed}
+            result['status'] = "Still Parsing your input"
+        return result
         
+    def _require_ready(self):
+        """Raise a UsageError unless parsing completed succesfully."""
+        if self._state == self.STATE_BAD:
+            raise UsageError(f'DCOLLECT parsing failed: {self._error}')
+        if self._state != self.STATE_READY:
+            raise UsageError('Not done parsing yet!')
+
     @property
     def datasets(self):
         """
@@ -912,25 +974,25 @@ class DCOLLECT:
 
 
         For an explanation of the fields go to : https://www.ibm.com/docs/en/zos/3.1.0?topic=output-dcollect-record-structure
-        """              
-        if self._state != self.STATE_READY:
-            print('no can do make nice error')
-        else:
-            return self.drecs
-    
+        """
+        self._require_ready()
+        return self.drecs
+
     @property
     def volumes(self):
-        if self._state != self.STATE_READY:
-            print('error also here')
-        else:
-            return self.vrecs
-        
+        self._require_ready()
+        return self.vrecs
+
     @property
     def dataclasses(self):
-        if self._state != self.STATE_READY:
-            print('Not done parsing yet')
-        else:
-            return self.dcrecs
+        self._require_ready()
+        return self.dcrecs
+
+    @property
+    def associations(self):
+        """Return parsed VSAM base-cluster association (A) records."""
+        self._require_ready()
+        return self.arecs
 
     def datasets_on_volume(self, volser=None):
         """

--- a/src/mfpandas/setropts.py
+++ b/src/mfpandas/setropts.py
@@ -196,11 +196,44 @@ class SETROPTS:
                     self._finfo = pd.read_pickle(pickle)
 
         
+    @classmethod
+    def from_setropts_list(cls, source):
+        """Build a :py:class:`SETROPTS` from raw ``SETROPTS LIST`` output.
+
+        This is an alternative to the IRRXUTIL REXX (:py:meth:`extractREXX`)
+        front-end. Instead of running the REXX on the mainframe and transferring
+        the ``_SETROPTS`` extract, you can capture ordinary ``SETROPTS LIST``
+        output (from a TSO session or the JES spool) and convert it locally.
+
+        :param source: Path to a file containing ``SETROPTS LIST`` output, or
+            the captured text itself.
+        :type source: str
+        :returns: A parsed :py:class:`SETROPTS` instance.
+
+        ::
+
+            >>> from mfpandas import SETROPTS
+            >>> s = SETROPTS.from_setropts_list('/home/henri/setropts-list.txt')
+            >>> s.classInfo
+        """
+        from .setropts_list import convert
+        if os.path.exists(source):
+            with open(source, 'r') as f:
+                text = f.read()
+        else:
+            text = source
+        obj = cls()
+        obj._build(convert(text))
+        return obj
+
     def _parse(self):
         with open(self._setropts, 'r') as f:
             kvpairs = f.read().splitlines()
+        self._build(kvpairs)
+
+    def _build(self, kvpairs):
         dict = {}
-        
+
         for kv in kvpairs:
             parts = kv.split(':', maxsplit=1)
             key = parts[0].strip()

--- a/src/mfpandas/setropts.py
+++ b/src/mfpandas/setropts.py
@@ -218,7 +218,9 @@ class SETROPTS:
             lists[f] = []
             
         for key in dict:
-            if len(dict[key]) == 1:
+            if key in self._setropts_lists:
+                lists[key] = dict[key]
+            else:
                 options['Setting'].append(key)
                 try:
                     # EPLS convert to int if possible
@@ -227,8 +229,6 @@ class SETROPTS:
                     dict[key][0] = dict[key][0]
                 options['Value'].append(dict[key][0])
                 options['Meaning'].append(self._setropts_fields[key])
-            else:
-                lists[key] = dict[key]
         # Fill not-specified ones
         for f in self._setropts_fields.keys():
             if f not in options['Setting']:

--- a/src/mfpandas/setropts_list.py
+++ b/src/mfpandas/setropts_list.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Convert RACF ``SETROPTS LIST`` output to IRRXUTIL key/value lines.
+
+The generated format is the one consumed by mfpandas/mfaudit:
+
+    CLASSACT:DATASET
+    INITSTAT:TRUE
+    INTERVAL:030
+
+Only settings represented by the IRRXUTIL SETROPTS extract are emitted.
+Terminal prompts, Ctrl-Z characters, and repeated captures are ignored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+TRUE = "TRUE"
+FALSE = "FALSE"
+
+
+def _report(text: str) -> str:
+    """Return the last SETROPTS LIST report from a terminal capture."""
+    text = text.replace("\x1a", "\n")
+    starts = list(
+        re.finditer(
+            r"(?im)^[ \t]*(?:1(?=SETROPTS))?SETROPTS[ \t]+LIST[ \t]*$",
+            text,
+        )
+    )
+    if not starts:
+        raise ValueError("input does not contain a SETROPTS LIST report")
+
+    # The last report is the most recent if a terminal capture contains several.
+    report = text[starts[-1].end() :]
+    end = re.search(r"(?im)^[ \t]*(?:READY|END)[ \t]*$", report)
+    if end:
+        report = report[: end.start()]
+    return report
+
+
+def _strip_asa_controls(report: str) -> str:
+    """Remove ASA carriage-control columns from an SDSF/JES spool capture."""
+    physical = report.splitlines()
+    # A page eject can prefix a continuation line with "1" followed by its
+    # original indentation, or a heading directly (for example
+    # "1PASSWORD PROCESSING OPTIONS:"). This is distinctive inside SETROPTS
+    # output and avoids modifying ordinary TSO captures.
+    has_asa = any(
+        re.match(r"^1(?:\s{2,}|PASSWORD PROCESSING OPTIONS:)", line, re.I)
+        for line in physical
+    )
+    if not has_asa:
+        return report
+
+    return "\n".join(
+        line[1:] if line and line[0] in " 01+-" else line for line in physical
+    )
+
+
+def _logical_lines(report: str) -> list[str]:
+    """Join wrapped SETROPTS list values while retaining ordinary lines."""
+    physical = report.splitlines()
+    logical: list[str] = []
+    i = 0
+    wrapped_header = re.compile(
+        r"^(?:"
+        r"STATISTICS|AUDIT CLASSES|ACTIVE CLASSES|"
+        r"GENERIC PROFILE CLASSES|GENERIC COMMAND CLASSES|"
+        r"GENLIST CLASSES|GLOBAL CHECKING CLASSES|"
+        r"SETR RACLIST CLASSES|GLOBAL=YES RACLIST ONLY|"
+        r'LOGOPTIONS "(?:ALWAYS|NEVER|SUCCESSES|FAILURES|DEFAULT)" CLASSES'
+        r")\s*=",
+        re.IGNORECASE,
+    )
+
+    while i < len(physical):
+        line = physical[i].rstrip()
+        stripped = line.strip()
+        if wrapped_header.match(stripped):
+            value = stripped
+            i += 1
+            while i < len(physical):
+                continuation = physical[i].rstrip()
+                # Wrapped class names are indented and contain only tokens.
+                if not re.match(r"^\s{2,}\S", continuation):
+                    break
+                candidate = continuation.strip()
+                if not re.fullmatch(r"[A-Z0-9#$@*?+\- ]+", candidate, re.I):
+                    break
+                value += " " + candidate
+                i += 1
+            logical.append(value)
+            continue
+        if stripped:
+            logical.append(stripped)
+        i += 1
+    return logical
+
+
+def _class_values(lines: Iterable[str], label: str) -> list[str]:
+    pattern = re.compile(rf"^{re.escape(label)}\s*=\s*(.*)$", re.I)
+    for line in lines:
+        match = pattern.match(line)
+        if match:
+            value = match.group(1).strip()
+            return [] if value.upper() == "NONE" else value.upper().split()
+    return []
+
+
+def _bool_token(attributes: str, yes: str, no: str) -> Optional[str]:
+    tokens = attributes.upper().split()
+    if yes in tokens:
+        return TRUE
+    if no in tokens:
+        return FALSE
+    return None
+
+
+def _has(report: str, pattern: str) -> bool:
+    return re.search(pattern, report, re.I | re.M) is not None
+
+
+def _match(report: str, pattern: str) -> Optional[re.Match[str]]:
+    return re.search(pattern, report, re.I | re.M)
+
+
+def convert(text: str) -> list[str]:
+    """Convert one terminal capture and return ``KEY:VALUE`` output lines."""
+    report = _strip_asa_controls(_report(text))
+    lines = _logical_lines(report)
+    # Terminal captures can prefix every output line with a blank. Wrapped
+    # class lists need their original indentation above, but scalar matching
+    # should not depend on terminal left margins.
+    report = "\n".join(line.strip() for line in report.splitlines())
+    output: list[str] = []
+
+    def emit(key: str, value: Optional[object]) -> None:
+        if value is not None:
+            output.append(f"{key}:{value}")
+
+    def emit_bool(key: str, positive: str, negative: str) -> None:
+        if _has(report, positive):
+            emit(key, TRUE)
+        elif _has(report, negative):
+            emit(key, FALSE)
+
+    # Repeat fields are emitted in the same useful order as the sample
+    # IRRXUTIL export. Empty/NONE repeat fields are absent from that export.
+    repeat_fields = (
+        ("CLASSACT", "ACTIVE CLASSES"),
+        ("GENCMD", "GENERIC COMMAND CLASSES"),
+        ("GENERIC", "GENERIC PROFILE CLASSES"),
+        ("RACLIST", "SETR RACLIST CLASSES"),
+        ("CLASSTAT", "STATISTICS"),
+        ("AUDIT", "AUDIT CLASSES"),
+        ("GENLIST", "GENLIST CLASSES"),
+        ("GLOBAL", "GLOBAL CHECKING CLASSES"),
+    )
+    for key, label in repeat_fields:
+        values = _class_values(lines, label)
+        # mfpandas <= 1.6 determines whether a key is a repeat field from the
+        # number of records instead of its field name. A valid one-item list
+        # (for example GLOBAL:DATASET) is consequently treated as a scalar and
+        # raises KeyError. Repeating the same value is semantically harmless:
+        # mfpandas uses membership tests when it builds classInfo.
+        if len(values) == 1:
+            values *= 2
+        for value in values:
+            emit(key, value)
+
+    attributes_match = _match(report, r"^\s*ATTRIBUTES\s*=\s*(.+)$")
+    attributes = attributes_match.group(1) if attributes_match else ""
+    emit("INITSTAT", _bool_token(attributes, "INITSTATS", "NOINITSTATS"))
+
+    terminal = _match(attributes, r"\bTERMINAL\((READ|NONE)\)")
+    # Current RACF output can omit the default from ATTRIBUTES, while the
+    # extract still returns TERMINAL:READ
+    emit("TERMINAL", terminal.group(1).upper() if terminal else "READ")
+
+    emit("CMDVIOL", _bool_token(attributes, "CMDVIOL", "NOCMDVIOL"))
+    emit("OPERAUDT", _bool_token(attributes, "OPERAUDIT", "NOOPERAUDIT"))
+    emit("SAUDIT", _bool_token(attributes, "SAUDIT", "NOSAUDIT"))
+    emit_bool(
+        "APPLAUDT",
+        r"^APPLAUDIT IS IN EFFECT\s*$",
+        r"^APPLAUDIT IS NOT IN EFFECT\s*$",
+    )
+    emit_bool(
+        "SLABAUDT",
+        r"^SECLABEL AUDIT IS IN EFFECT\s*$",
+        r"^SECLABEL AUDIT IS NOT IN EFFECT\s*$",
+    )
+
+    log_fields = (
+        ("LOGALWYS", 'LOGOPTIONS "ALWAYS" CLASSES'),
+        ("LOGNEVER", 'LOGOPTIONS "NEVER" CLASSES'),
+        ("LOGSUCC", 'LOGOPTIONS "SUCCESSES" CLASSES'),
+        ("LOGFAIL", 'LOGOPTIONS "FAILURES" CLASSES'),
+        ("LOGDEFLT", 'LOGOPTIONS "DEFAULT" CLASSES'),
+    )
+    for key, label in log_fields:
+        values = _class_values(lines, label)
+        if len(values) == 1:
+            values *= 2
+        for value in values:
+            emit(key, value)
+
+    match = _match(report, r"^\s*(\d+)\s+GENERATIONS? OF PREVIOUS PASSWORDS")
+    if match:
+        emit("HISTORY", f"{int(match.group(1)):03d}")
+
+    match = _match(report, r"PASSWORD CHANGE INTERVAL IS\s+(\d+)\s+DAYS")
+    if match:
+        emit("INTERVAL", f"{int(match.group(1)):03d}")
+
+    match = _match(report, r"PASSWORD PHRASE CHANGE INTERVAL IS\s+(\d+)\s+DAYS")
+    if match:
+        emit("PHRINT", f"{int(match.group(1)):05d}")
+
+    match = _match(report, r"PASSWORD MINIMUM CHANGE INTERVAL IS\s+(\d+)\s+DAYS")
+    if match:
+        emit("MINCHANG", f"{int(match.group(1)):03d}")
+
+    emit_bool(
+        "MIXDCASE",
+        r"MIXED CASE PASSWORD SUPPORT IS IN EFFECT",
+        r"MIXED CASE PASSWORD SUPPORT IS NOT IN EFFECT",
+    )
+    emit_bool(
+        "PWDSPEC",
+        r"SPECIAL CHARACTERS ARE ALLOWED",
+        r"(?:SPECIAL CHARACTERS ARE NOT|NO SPECIAL CHARACTERS ARE) ALLOWED",
+    )
+
+    match = _match(report, r"ACTIVE PASSWORD ENCRYPTION ALGORITHM IS\s+(\S+)")
+    if match:
+        emit("PWDALG", match.group(1).upper().rstrip("."))
+
+    for match in re.finditer(
+        r"^\s*RULE\s+([1-8])\s+LENGTH\((\d+)(?::(\d+))?\)\s+(\S+)",
+        report,
+        re.I | re.M,
+    ):
+        number, minimum, maximum, sequence = match.groups()
+        maximum = maximum or minimum
+        emit(f"RULE{number}", f"{int(minimum)}:{int(maximum)} {sequence}")
+
+    match = _match(
+        report,
+        r"AFTER\s+(\d+)\s+CONSECUTIVE UNSUCCESSFUL PASSWORD ATTEMPTS,"
+        r"\s*A USERID WILL BE REVOKED",
+    )
+    if match:
+        emit("REVOKE", f"{int(match.group(1)):03d}")
+
+    match = _match(report, r"PASSWORD EXPIRATION WARNING LEVEL IS\s+(\d+)\s+DAYS")
+    if match:
+        emit("WARNING", f"{int(match.group(1)):03d}")
+
+    emit_bool(
+        "ADDCREAT",
+        r"^ADDCREATOR IS IN EFFECT\s*$",
+        r"^ADDCREATOR IS NOT IN EFFECT\s*$",
+    )
+    emit_bool(
+        "ADSP",
+        r"^AUTOMATIC DATASET PROTECTION IS IN EFFECT\s*$",
+        r"^AUTOMATIC DATASET PROTECTION IS NOT IN EFFECT\s*$",
+    )
+    emit_bool(
+        "COMPMODE",
+        r"^COMPATIBILITY MODE IS IN EFFECT\s*$",
+        r"^COMPATIBILITY MODE IS NOT IN EFFECT\s*$",
+    )
+    emit_bool(
+        "EGN",
+        r"^ENHANCED GENERIC NAMING IS IN EFFECT\s*$",
+        r"^ENHANCED GENERIC NAMING IS NOT IN EFFECT\s*$",
+    )
+    emit_bool(
+        "GENOWNER",
+        r"^GENERIC OWNER ONLY IS IN EFFECT\s*$",
+        r"^GENERIC OWNER ONLY IS NOT IN EFFECT\s*$",
+    )
+    emit_bool(
+        "GRPLIST",
+        r"^LIST OF GROUPS ACCESS CHECKING IS ACTIVE",
+        r"^LIST OF GROUPS ACCESS CHECKING IS INACTIVE",
+    )
+    emit_bool(
+        "MLQUIET",
+        r"^MULTI-LEVEL QUIET IS IN EFFECT\s*$",
+        r"^MULTI-LEVEL QUIET IS NOT IN EFFECT\s*$",
+    )
+    emit_bool(
+        "MLSTABLE",
+        r"^MULTI-LEVEL STABLE IS IN EFFECT\s*$",
+        r"^MULTI-LEVEL STABLE IS NOT IN EFFECT\s*$",
+    )
+    emit_bool(
+        "MLNAMES",
+        r"^MULTI-LEVEL NAME HIDING IS IN EFFECT\s*$",
+        r"^MULTI-LEVEL NAME HIDING IS NOT IN EFFECT\s*$",
+    )
+    emit_bool(
+        "SLBYSYS",
+        r"^SECURITY LABEL BY SYSTEM IS IN EFFECT\s*$",
+        r"^SECURITY LABEL BY SYSTEM IS NOT IN EFFECT\s*$",
+    )
+
+    if _has(report, r"^MULTI-LEVEL INTERPROCESS COMMUNICATIONS IS NOT IN EFFECT"):
+        emit("MLIPC", "INACTIVE")
+    if _has(report, r"^MULTI-LEVEL FILE SYSTEM IS NOT IN EFFECT"):
+        emit("MLFS", "INACTIVE")
+
+    emit_bool(
+        "REALDSN",
+        r"^REAL DATA SET NAMES OPTION IS ACTIVE\s*$",
+        r"^REAL DATA SET NAMES OPTION IS INACTIVE\s*$",
+    )
+
+    if _has(report, r"^PROTECT-ALL IS ACTIVE"):
+        if _has(report, r"^\s*PROTECT-ALL WARNING OPTION IS IN EFFECT"):
+            emit("PROTALL", "WARNING")
+        else:
+            # SETROPTS LIST calls the FAILURES mode "FAIL"; FAILURES is also
+            # the RACF default when PROTECTALL is active without a suboption.
+            emit("PROTALL", "FAILURES")
+
+    match = _match(report, r"SECURITY RETENTION PERIOD IN EFFECT IS\s+(\d+)\s+DAYS")
+    if match:
+        emit("RETPD", f"{int(match.group(1)):05d}")
+
+    for key, function in (("RVARSWPW", "SWITCH"), ("RVARSTPW", "STATUS")):
+        if _has(
+            report,
+            rf"^DEFAULT RVARY PASSWORD IS IN EFFECT FOR THE {function} FUNCTION",
+        ):
+            emit(key, "DEFAULT")
+        elif _has(
+            report,
+            rf"^INSTALLATION(?:[ -]DEFINED)? RVARY PASSWORD IS IN EFFECT "
+            rf"FOR THE {function} FUNCTION",
+        ):
+            emit(key, "INSTLN")
+
+    emit_bool(
+        "SECLABCT",
+        r"^SECLABEL CONTROL IS IN EFFECT\s*$",
+        r"^SECLABEL CONTROL IS NOT IN EFFECT\s*$",
+    )
+
+    match = _match(
+        report,
+        r"PARTNER LU-VERIFICATION SESSIONKEY INTERVAL MAXIMUM/DEFAULT IS\s+"
+        r"(\d+)\s+DAYS",
+    )
+    if match:
+        emit("SESSINT", f"{int(match.group(1)):05d}")
+
+    emit_bool(
+        "TAPEDSN",
+        r"^TAPE DATA SET PROTECTION IS ACTIVE\s*$",
+        r"^TAPE DATA SET PROTECTION IS INACTIVE\s*$",
+    )
+    if re.search(r"\bNOWHEN\(PROGRAM", attributes, re.I):
+        emit("WHENPROG", FALSE)
+    elif re.search(r"\bWHEN\(PROGRAM(?:\s*--[^)]*)?\)", attributes, re.I):
+        emit("WHENPROG", TRUE)
+
+    no_model = _has(report, r"^NO DATA SET MODELLING BEING DONE")
+    if no_model:
+        emit("MODGDG", FALSE)
+        emit("MODGROUP", FALSE)
+        emit("MODUSER", FALSE)
+        emit("MODEL", FALSE)
+    else:
+        emit_bool(
+            "MODGDG",
+            r"^DATA SET MODELLING IS BEING DONE FOR GDGS",
+            r"^DATA SET MODELLING NOT BEING DONE FOR GDGS",
+        )
+        emit_bool(
+            "MODGROUP",
+            r"^GROUP DATA SET MODELLING IS BEING DONE",
+            r"^GROUP DATA SET MODELLING IS NOT BEING DONE",
+        )
+        emit_bool(
+            "MODUSER",
+            r"^USER DATA SET MODELLING IS BEING DONE",
+            r"^USER DATA SET MODELLING IS NOT BEING DONE",
+        )
+
+    emit_bool(
+        "ERASE",
+        r"^ERASE-ON-SCRATCH IS ACTIVE\s*$",
+        r"^ERASE-ON-SCRATCH IS INACTIVE\s*$",
+    )
+
+    match = _match(report, r"^PRIMARY LANGUAGE DEFAULT\s*:\s*(\S+)")
+    if match:
+        emit("PRIMLANG", match.group(1).upper())
+    match = _match(report, r"^SECONDARY LANGUAGE DEFAULT\s*:\s*(\S+)")
+    if match:
+        emit("SECLANG", match.group(1).upper())
+
+    emit_bool(
+        "JESBATCH",
+        r"^JES-BATCHALLRACF OPTION IS ACTIVE\s*$",
+        r"^JES-BATCHALLRACF OPTION IS INACTIVE\s*$",
+    )
+    emit_bool(
+        "JESEARLY",
+        r"^JES-EARLYVERIFY OPTION IS ACTIVE\s*$",
+        r"^JES-EARLYVERIFY OPTION IS INACTIVE\s*$",
+    )
+    emit_bool(
+        "JESXBM",
+        r"^JES-XBMALLRACF OPTION IS ACTIVE\s*$",
+        r"^JES-XBMALLRACF OPTION IS INACTIVE\s*$",
+    )
+
+    match = _match(report, r"^USER-ID FOR JES NJEUSERID IS\s*:\s*(\S+)")
+    if match:
+        emit("JESNJE", match.group(1))
+    match = _match(report, r"^USER-ID FOR JES UNDEFINEDUSER IS\s*:\s*(\S+)")
+    if match:
+        emit("JESUNDEF", match.group(1))
+    match = _match(report, r"^KERBLVL\s*=\s*(\d+)")
+    if match:
+        emit("KERBLVL", f"{int(match.group(1)):03d}")
+
+    return output
+
+
+def _read(path: Path, encoding: str) -> str:
+    try:
+        return path.read_text(encoding=encoding)
+    except UnicodeDecodeError as error:
+        raise ValueError(
+            f"cannot decode {path} as {encoding}; specify the transferred "
+            "text file's encoding with --encoding"
+        ) from error
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert RACF SETROPTS LIST text to mfpandas/mfaudit KEY:VALUE format"
+        )
+    )
+    parser.add_argument("input", type=Path, help="SETROPTS LIST text file")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="output file (default: standard output)",
+    )
+    parser.add_argument(
+        "--encoding",
+        default="utf-8",
+        help="input/output text encoding (default: utf-8)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        result = "\n".join(convert(_read(args.input, args.encoding))) + "\n"
+        if args.output:
+            with args.output.open("w", encoding=args.encoding, newline="\n") as stream:
+                stream.write(result)
+        else:
+            sys.stdout.write(result)
+    except (OSError, ValueError) as error:
+        parser.exit(2, f"error: {error}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Test against src/, not against whatever mfpandas happens to be installed.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))

--- a/tests/test_dcollect.py
+++ b/tests/test_dcollect.py
@@ -1,0 +1,135 @@
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from mfpandas import DCOLLECT
+from mfpandas.dcollect import UsageError
+
+
+def _record(record_type, length=470):
+    data = bytearray(length)
+    data[0:2] = length.to_bytes(2, "big")
+    data[4:6] = record_type.ljust(2).encode("cp500")
+    return data
+
+
+class DCOLLECTTests(unittest.TestCase):
+    def setUp(self):
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.tempdir = Path(self._tempdir.name)
+
+    def tearDown(self):
+        self._tempdir.cleanup()
+
+    def test_zero_dataset_dates_are_missing(self):
+        record = _record("D")
+        record[24:68] = "TEST.DATA".ljust(44).encode("cp500")
+        record[78:84] = "VOL001".encode("cp500")
+        record[386:388] = bytes.fromhex("FFFF")
+        path = self.tempdir / "dcollect.bin"
+        path.write_bytes(record)
+
+        parsed = DCOLLECT(str(path))
+
+        self.assertTrue(parsed.parse_t())
+        self.assertEqual(parsed.status["status"], "Ready")
+        self.assertEqual(parsed.datasets.iloc[0]["DCDDSNAM"], "TEST.DATA")
+        self.assertIsNone(parsed.datasets.iloc[0]["DCDCREDT"])
+        self.assertEqual(parsed.datasets.iloc[0]["DCDATYPE"], "FFFF")
+        self.assertEqual(parsed.datasets.iloc[0]["DCDAKLBL"], "")
+
+    def test_encrypted_dataset_exposes_key_label(self):
+        record = _record("D")
+        record[24:68] = "SECRET.DATA".ljust(44).encode("cp500")
+        record[386:388] = bytes.fromhex("0100")
+        record[388:452] = "KEY.LABEL.ONE".ljust(64).encode("cp500")
+        path = self.tempdir / "encrypted.bin"
+        path.write_bytes(record)
+
+        parsed = DCOLLECT(str(path))
+
+        self.assertTrue(parsed.parse_t())
+        self.assertEqual(parsed.datasets.iloc[0]["DCDATYPE"], "0100")
+        self.assertEqual(parsed.datasets.iloc[0]["DCDAKLBL"], "KEY.LABEL.ONE")
+
+    def test_short_dataset_record_has_no_encryption_fields(self):
+        # D-records predating APAR OA51067 stop before DCDAENCR.
+        record = _record("D", length=300)
+        record[24:68] = "OLD.DATA".ljust(44).encode("cp500")
+        path = self.tempdir / "short.bin"
+        path.write_bytes(record)
+
+        parsed = DCOLLECT(str(path))
+
+        self.assertTrue(parsed.parse_t())
+        self.assertEqual(parsed.datasets.iloc[0]["DCDATYPE"], "")
+        self.assertEqual(parsed.datasets.iloc[0]["DCDAKLBL"], "")
+
+    def test_background_parse_reports_malformed_record(self):
+        path = self.tempdir / "bad-dcollect.bin"
+        path.write_bytes(b"\x00\x00")
+        parsed = DCOLLECT(str(path))
+
+        parsed.parse()
+        for _ in range(100):
+            if parsed.status["status"] == "Error":
+                break
+            time.sleep(0.01)
+
+        self.assertEqual(parsed.status["status"], "Error")
+        self.assertIn("Invalid DCOLLECT record length", parsed.status["error"])
+
+    def test_failed_parse_surfaces_error_on_dataframes(self):
+        path = self.tempdir / "bad-dcollect.bin"
+        path.write_bytes(b"\x00\x00")
+        parsed = DCOLLECT(str(path))
+
+        self.assertFalse(parsed.parse_t())
+        with self.assertRaises(UsageError) as raised:
+            parsed.datasets
+        self.assertIn("Invalid DCOLLECT record length", str(raised.exception))
+
+    def test_truncated_association_record_is_reported(self):
+        record = _record("A", length=100)
+        path = self.tempdir / "short-association.bin"
+        path.write_bytes(record)
+
+        parsed = DCOLLECT(str(path))
+
+        self.assertFalse(parsed.parse_t())
+        self.assertIn("Truncated DCOLLECT A-record", parsed.status["error"])
+
+    def test_vsam_association_records_are_exposed(self):
+        record = _record("A", length=204)
+        record[24:68] = "APP.INDEX".ljust(44).encode("cp500")
+        record[68:112] = "APP.CLUSTER".ljust(44).encode("cp500")
+        record[112] = 0b10000000
+        path = self.tempdir / "associations.bin"
+        path.write_bytes(record)
+
+        parsed = DCOLLECT(str(path))
+
+        self.assertTrue(parsed.parse_t())
+        row = parsed.associations.iloc[0]
+        self.assertEqual(row["DCADSNAM"], "APP.INDEX")
+        self.assertEqual(row["DCAASSOC"], "APP.CLUSTER")
+        self.assertTrue(bool(row["DCAKSDS"]))
+
+    def test_counters_are_not_shared_between_instances(self):
+        record = _record("D")
+        record[24:68] = "TEST.DATA".ljust(44).encode("cp500")
+        path = self.tempdir / "dcollect.bin"
+        path.write_bytes(record)
+
+        first = DCOLLECT(str(path))
+        first.parse_t()
+        second = DCOLLECT(str(path))
+        second.parse_t()
+
+        self.assertEqual(first.records_seen["D"], 1)
+        self.assertEqual(second.records_seen["D"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setropts.py
+++ b/tests/test_setropts.py
@@ -1,0 +1,51 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from mfpandas import SETROPTS
+
+
+class SETROPTSTests(unittest.TestCase):
+    def setUp(self):
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.tempdir = Path(self._tempdir.name)
+
+    def tearDown(self):
+        self._tempdir.cleanup()
+
+    def _extract(self, *kvpairs):
+        path = self.tempdir / 'setropts.txt'
+        path.write_text('\n'.join(kvpairs) + '\n')
+        return SETROPTS(str(path))
+
+    def test_single_entry_list_is_not_a_setting(self):
+        # Exactly one RACLISTed class used to be parsed as a key/value setting,
+        # which then blew up on the _setropts_fields lookup.
+        s = self._extract(
+            'RACLIST:FACILITY',
+            'CLASSACT:FACILITY',
+            'CLASSACT:TSOAUTH',
+            'INTERVAL:180',
+        )
+
+        self.assertNotIn('RACLIST', list(s.fieldInfo['Setting']))
+        facility = s.classInfo[s.classInfo['name'] == 'FACILITY'].iloc[0]
+        self.assertEqual(facility['RACLIST'], 'YES')
+        self.assertEqual(facility['CLASSACT'], 'YES')
+
+    def test_multi_entry_list_still_parses(self):
+        s = self._extract('RACLIST:FACILITY', 'RACLIST:TSOAUTH')
+
+        raclisted = set(s.classInfo[s.classInfo['RACLIST'] == 'YES']['name'])
+        self.assertEqual(raclisted, {'FACILITY', 'TSOAUTH'})
+
+    def test_settings_are_still_key_value_pairs(self):
+        s = self._extract('INTERVAL:180', 'MIXDCASE:TRUE')
+
+        settings = s.fieldInfo.set_index('Setting')['Value']
+        self.assertEqual(settings['INTERVAL'], 180)
+        self.assertEqual(settings['MIXDCASE'], 'TRUE')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_setropts_list.py
+++ b/tests/test_setropts_list.py
@@ -1,0 +1,75 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from mfpandas import SETROPTS
+from mfpandas.setropts_list import convert
+
+
+# A trimmed but realistically ordered SETROPTS LIST capture: general options and
+# password options first, class lists last (wrapped-header lists must be the
+# final indented block so continuation joining does not swallow later lines).
+SETROPTS_LIST = """\
+READY
+  SETROPTS LIST
+  ATTRIBUTES = INITSTATS NOCMDVIOL SAUDIT OPERAUDIT
+  PASSWORD PROCESSING OPTIONS:
+    PASSWORD CHANGE INTERVAL IS  180 DAYS.
+    PASSWORD MINIMUM CHANGE INTERVAL IS   0 DAYS.
+    MIXED CASE PASSWORD SUPPORT IS IN EFFECT.
+     8 GENERATIONS OF PREVIOUS PASSWORDS BEING MAINTAINED.
+    AFTER   5 CONSECUTIVE UNSUCCESSFUL PASSWORD ATTEMPTS, A USERID WILL BE REVOKED.
+  ERASE-ON-SCRATCH IS INACTIVE
+  ACTIVE CLASSES  =  DATASET USER GROUP FACILITY TSOAUTH
+  GENERIC PROFILE CLASSES  =  DATASET FACILITY
+  SETR RACLIST CLASSES  =  FACILITY
+READY
+"""
+
+
+class ConvertTests(unittest.TestCase):
+    def test_emits_expected_key_value_pairs(self):
+        lines = convert(SETROPTS_LIST)
+
+        self.assertIn('INITSTAT:TRUE', lines)
+        self.assertIn('CMDVIOL:FALSE', lines)
+        self.assertIn('INTERVAL:180', lines)
+        self.assertIn('HISTORY:008', lines)
+        self.assertIn('REVOKE:005', lines)
+        self.assertIn('ERASE:FALSE', lines)
+        # Class membership is emitted as one record per class.
+        self.assertIn('CLASSACT:FACILITY', lines)
+        self.assertIn('GENERIC:DATASET', lines)
+        self.assertIn('RACLIST:FACILITY', lines)
+
+    def test_rejects_non_setropts_input(self):
+        with self.assertRaises(ValueError):
+            convert('READY\n  LISTGRP SYS1\nREADY\n')
+
+
+class FromSetroptsListTests(unittest.TestCase):
+    def test_from_text_builds_dataframes(self):
+        s = SETROPTS.from_setropts_list(SETROPTS_LIST)
+
+        settings = s.fieldInfo.set_index('Setting')['Value']
+        self.assertEqual(settings['INTERVAL'], 180)
+        self.assertEqual(settings['INITSTAT'], 'TRUE')
+        self.assertEqual(settings['ERASE'], 'FALSE')
+
+        facility = s.classInfo[s.classInfo['name'] == 'FACILITY'].iloc[0]
+        self.assertEqual(facility['CLASSACT'], 'YES')
+        self.assertEqual(facility['GENERIC'], 'YES')
+        self.assertEqual(facility['RACLIST'], 'YES')
+
+    def test_from_file_matches_from_text(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'setropts-list.txt'
+            path.write_text(SETROPTS_LIST)
+            from_file = SETROPTS.from_setropts_list(str(path))
+
+        from_text = SETROPTS.from_setropts_list(SETROPTS_LIST)
+        self.assertTrue(from_file.fieldInfo.equals(from_text.fieldInfo))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Report DCOLLECT parse failures instead of hanging
A parse error inside the background thread killed the thread silently,
leaving status stuck on "Still Parsing your input" forever. Failures now
land in STATE_BAD and surface via status['error'] and the dataframe
properties, which raise UsageError instead of printing placeholder text
and returning None.
Also parse A-records (VSAM associations), expose the DCDAENCR encryption
fields as DCDATYPE and DCDAKLBL, and return None rather than False for
zero and invalid packed dates.
- Add DCOLLECT tests
- Fix SETROPTS list detection for single-entry lists
- Add SETROPTS to tests